### PR TITLE
push-stack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ any files with `C-u` prefix.
 Move to previous point on the stack.
 helm-gtags pushes current point to stack before executing each jump functions.
 
+#### `helm-gtags-push-stack`
+
+Push current location to the stack.
+
 #### `helm-gtags-next-history`
 
 Move to next history on context stack.

--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -1200,6 +1200,12 @@ You can jump definitions of functions, symbols in this file."
           :buffer helm-gtags--buffer :preselect presel)))
 
 ;;;###autoload
+(defun helm-gtags-push-stack ()
+  "Push current location to the stack."
+  (interactive)
+  (helm-gtags--push-context (helm-gtags--current-context)))
+
+;;;###autoload
 (defun helm-gtags-pop-stack ()
   "Jump to previous point on the context stack and pop it from stack."
   (interactive)


### PR DESCRIPTION
This little patch adds a new interactive function to the api: `helm-gtags-push-stack`.

My motivation is I can typically jump around the code with the current api, but in some cases I use `helm-grep-do-git-grep` for jump, for example when I do not exactly know what is the tag I am looking for, or when I am looking for a complex expression. Even then my muscle memory triggers the helm-gtags-pop-stack, which jumps to a wrong location, as `helm-grep-do-git-grep` does not push location to the stack. With `helm-gtags-push-stack`, I could `advice-add`  `helm-grep-do-git-grep` to push the location before search, letting me to continue to use `helm-gtags-pop-stack` safely.

In general, this function can be used to make other modules compatible with `helm-gtags`.